### PR TITLE
Comment out Poseidon Mina tests due to using the last element as hash value

### DIFF
--- a/test/poseidon.cpp
+++ b/test/poseidon.cpp
@@ -97,104 +97,108 @@ void test_original_poseidon(
     BOOST_CHECK_EQUAL(input, expected_result);
 }
 
-BOOST_AUTO_TEST_SUITE(poseidon_manual_tests)
+BOOST_AUTO_TEST_SUITE(poseidon_tests)
 
-BOOST_AUTO_TEST_CASE(poseidon_kimchi_test_0) {
-    test_mina_poseidon<fields::pallas_base_field>(
-        {}, 0x2FADBE2852044D028597455BC2ABBD1BC873AF205DFABB8A304600F3E09EEBA8_cppui254);
-}
-
-BOOST_AUTO_TEST_CASE(poseidon_kimchi_test_1) {
-    test_mina_poseidon<fields::pallas_base_field>(
-        {0x36FB00AD544E073B92B4E700D9C49DE6FC93536CAE0C612C18FBE5F6D8E8EEF2_cppui254},
-        0x3D4F050775295C04619E72176746AD1290D391D73FF4955933F9075CF69259FB_cppui254
-    );
-}
-
-BOOST_AUTO_TEST_CASE(poseidon_kimchi_test_2) {
-    test_mina_poseidon<fields::pallas_base_field>(
-        {0x3793E30AC691700012BAF26BB813D6D70BD379BEED8050A1DEEE3C188F1C3FBD_cppui254,
-         0x2FC4C98E50E0B1AAE6ECB468E28C0B7D80A7E0EEC7136DB0BA0677B84AF0E465_cppui254},
-        0x336C73D08AD408CEB7D1264867096F0817A1D0558B313312A1207602F23624FE_cppui254
-    );
-}
-
-BOOST_AUTO_TEST_CASE(poseidon_kimchi_test_3) {
-    test_mina_poseidon<fields::pallas_base_field>(
-        {0x0024FB5773CAC987CF3A17DDD6134BA12D3E1CA4F6C43D3695347747CE61EAF5_cppui254,
-        0x18E0ED2B46ED1EC258DF721A1D3145B0AA6ABDD02EE851A14B8B659CF47385F2_cppui254,
-        0x1A842A688E600F012637FE181292F70C4347B5AE0D9EA9CE7CF18592C345CF73_cppui254},
-        0x3F4B0EABB64E025F920457AF8D090A9F6472CAE11F3D62A749AF544A44941B9B_cppui254);
-}
-
-BOOST_AUTO_TEST_CASE(poseidon_kimchi_test_4) {
-    test_mina_poseidon<fields::pallas_base_field>(
-        {0x2059462D60621F70620EA697FA1382EC5553A3DADB3CF9072201E09871B8284C_cppui254,
-         0x2747337D1C4F9894747074C771E8EC7F570640E5D0CAF30FDDC446C00FA48707_cppui254,
-         0x2DD5047C3EEEF37930E8FA4AD9691B27CF86D3ED39D4DEC4FC6D4E8EE4FF0415_cppui254,
-         0x12C387C69BDD436F65AB607A4ED7C62714872EDBF800518B58E76F5106650B29_cppui254},
-        0x165A8CECF6660C6E0054CB9B4DBA9D68047166D7F3CED2F8DC86ED2EBFD3EC47_cppui254);
-}
-
-BOOST_AUTO_TEST_CASE(poseidon_kimchi_test_5) {
-    test_mina_poseidon<fields::pallas_base_field>(
-        {0x3CF70C3A89749A45DB5236B8DE167A37762526C45270138A9FCDF2352B1899DA_cppui254,
-         0x1BDF55BC84C1A0E0F7F6834949FCF90279B9D21C17DBC9928202C49039570598_cppui254,
-         0x09441E95A82199EFC390152C5039C0D0566A90B7F6D1AA5813B2DAB90110FF90_cppui254,
-         0x375B4A9785503C24531723DB1F31B50B79C3D1EC9F95DB7645A3EDA03862B588_cppui254,
-         0x12688FE351ED01F3BB2EB6B0FA2A70FB232654F32B08990DC3A411E527776A89_cppui254},
-        0x0CA2C3342C2959D7CD94B5C9D4DC55900F5F60B345F714827C8B907752D5A209_cppui254);
-}
-
-BOOST_AUTO_TEST_CASE(poseidon_kimchi_test_6) {
-    // This test just checks, that absorb does nothing when squeeze not called.
-    using field_type = fields::pallas_base_field;
-    using poseidon_policy = mina_poseidon_policy<field_type>;
-    using sponge_construction_type = poseidon_sponge_construction<poseidon_policy>;
-
-    std::vector<field_type::value_type> input = {
-        0x1A3FBD7D8C00BD0C3D4BC1DD41BF7FAA5903518DA636955D98712F9AC6D6DDFA_cppui254,
-        0x1AA195509819DF535E832D7D8AF809B385EF96A85A5A2DCE0DB7F9D72954F829_cppui254};
-    std::array<typename poseidon_policy::element_type, poseidon_policy::state_words> expected_state = {
-        0x1A3FBD7D8C00BD0C3D4BC1DD41BF7FAA5903518DA636955D98712F9AC6D6DDFA_cppui254,
-        0x1AA195509819DF535E832D7D8AF809B385EF96A85A5A2DCE0DB7F9D72954F829_cppui254,
-        0
-    };
-    sponge_construction_type sponge;
-    
-    sponge.absorb(input);
-
-    BOOST_CHECK_EQUAL(sponge.state, expected_state);
-}
-
-BOOST_AUTO_TEST_CASE(poseidon_kimchi_test_7) {
-    using field_type = fields::pallas_base_field;
-    using poseidon_policy = mina_poseidon_policy<field_type>;
-    using sponge_construction_type = poseidon_sponge_construction<poseidon_policy>;
-
-    std::vector<field_type::value_type> input = {
-        0x3CF70C3A89749A45DB5236B8DE167A37762526C45270138A9FCDF2352B1899DA_cppui254,
-        0x1BDF55BC84C1A0E0F7F6834949FCF90279B9D21C17DBC9928202C49039570598_cppui254,
-        0x09441E95A82199EFC390152C5039C0D0566A90B7F6D1AA5813B2DAB90110FF90_cppui254,
-        0x375B4A9785503C24531723DB1F31B50B79C3D1EC9F95DB7645A3EDA03862B588_cppui254,
-        0x12688FE351ED01F3BB2EB6B0FA2A70FB232654F32B08990DC3A411E527776A89_cppui254};
-
-    std::array<typename poseidon_policy::element_type, poseidon_policy::state_words>  expected_state_absorb = {
-        0x2437F72484D8C5483D75F898376BC3EE29EDF2F7EF5305A3C61B937654954000_cppui254,
-        0x16F954CD8F2B73D797170C5124F31A65160A3FCA92B77709E564075C2405BF80_cppui254,
-        0x3696E4E8F08273FFEFDAD72C5002D103E9B8976F6579A010D6CC2A75B276851F_cppui254};
-    sponge_construction_type sponge;
-    
-    sponge.absorb(input);
-
-    BOOST_CHECK(sponge.state == expected_state_absorb);
-
-    typename poseidon_policy::element_type expected_challenge = 
-        0x0CA2C3342C2959D7CD94B5C9D4DC55900F5F60B345F714827C8B907752D5A209_cppui254;
-    typename poseidon_policy::element_type challenge = sponge.squeeze();
-
-    BOOST_CHECK_EQUAL(challenge, expected_challenge);
-}
+// All the tests for mina poseidon will fail, since we made a decision to take the last element of the permuted state 
+// (which is state[2] for Rate = 2) as the result of hash after squeeze. Mina poseidon uses the first element state[0] as the result. 
+// So after this change, their test vectors do not apply any more.
+// In case we decide to undo this change, these test vectors will be used again.
+//BOOST_AUTO_TEST_CASE(poseidon_kimchi_test_0) {
+//    test_mina_poseidon<fields::pallas_base_field>(
+//        {}, 0x2FADBE2852044D028597455BC2ABBD1BC873AF205DFABB8A304600F3E09EEBA8_cppui254);
+//}
+//
+//BOOST_AUTO_TEST_CASE(poseidon_kimchi_test_1) {
+//    test_mina_poseidon<fields::pallas_base_field>(
+//        {0x36FB00AD544E073B92B4E700D9C49DE6FC93536CAE0C612C18FBE5F6D8E8EEF2_cppui254},
+//        0x3D4F050775295C04619E72176746AD1290D391D73FF4955933F9075CF69259FB_cppui254
+//    );
+//}
+//
+//BOOST_AUTO_TEST_CASE(poseidon_kimchi_test_2) {
+//    test_mina_poseidon<fields::pallas_base_field>(
+//        {0x3793E30AC691700012BAF26BB813D6D70BD379BEED8050A1DEEE3C188F1C3FBD_cppui254,
+//         0x2FC4C98E50E0B1AAE6ECB468E28C0B7D80A7E0EEC7136DB0BA0677B84AF0E465_cppui254},
+//        0x336C73D08AD408CEB7D1264867096F0817A1D0558B313312A1207602F23624FE_cppui254
+//    );
+//}
+//
+//BOOST_AUTO_TEST_CASE(poseidon_kimchi_test_3) {
+//    test_mina_poseidon<fields::pallas_base_field>(
+//        {0x0024FB5773CAC987CF3A17DDD6134BA12D3E1CA4F6C43D3695347747CE61EAF5_cppui254,
+//        0x18E0ED2B46ED1EC258DF721A1D3145B0AA6ABDD02EE851A14B8B659CF47385F2_cppui254,
+//        0x1A842A688E600F012637FE181292F70C4347B5AE0D9EA9CE7CF18592C345CF73_cppui254},
+//        0x3F4B0EABB64E025F920457AF8D090A9F6472CAE11F3D62A749AF544A44941B9B_cppui254);
+//}
+//
+//BOOST_AUTO_TEST_CASE(poseidon_kimchi_test_4) {
+//    test_mina_poseidon<fields::pallas_base_field>(
+//        {0x2059462D60621F70620EA697FA1382EC5553A3DADB3CF9072201E09871B8284C_cppui254,
+//         0x2747337D1C4F9894747074C771E8EC7F570640E5D0CAF30FDDC446C00FA48707_cppui254,
+//         0x2DD5047C3EEEF37930E8FA4AD9691B27CF86D3ED39D4DEC4FC6D4E8EE4FF0415_cppui254,
+//         0x12C387C69BDD436F65AB607A4ED7C62714872EDBF800518B58E76F5106650B29_cppui254},
+//        0x165A8CECF6660C6E0054CB9B4DBA9D68047166D7F3CED2F8DC86ED2EBFD3EC47_cppui254);
+//}
+//
+//BOOST_AUTO_TEST_CASE(poseidon_kimchi_test_5) {
+//    test_mina_poseidon<fields::pallas_base_field>(
+//        {0x3CF70C3A89749A45DB5236B8DE167A37762526C45270138A9FCDF2352B1899DA_cppui254,
+//         0x1BDF55BC84C1A0E0F7F6834949FCF90279B9D21C17DBC9928202C49039570598_cppui254,
+//         0x09441E95A82199EFC390152C5039C0D0566A90B7F6D1AA5813B2DAB90110FF90_cppui254,
+//         0x375B4A9785503C24531723DB1F31B50B79C3D1EC9F95DB7645A3EDA03862B588_cppui254,
+//         0x12688FE351ED01F3BB2EB6B0FA2A70FB232654F32B08990DC3A411E527776A89_cppui254},
+//        0x0CA2C3342C2959D7CD94B5C9D4DC55900F5F60B345F714827C8B907752D5A209_cppui254);
+//}
+//
+//BOOST_AUTO_TEST_CASE(poseidon_kimchi_test_6) {
+//    // This test just checks, that absorb does nothing when squeeze not called.
+//    using field_type = fields::pallas_base_field;
+//    using poseidon_policy = mina_poseidon_policy<field_type>;
+//    using sponge_construction_type = poseidon_sponge_construction<poseidon_policy>;
+//
+//    std::vector<field_type::value_type> input = {
+//        0x1A3FBD7D8C00BD0C3D4BC1DD41BF7FAA5903518DA636955D98712F9AC6D6DDFA_cppui254,
+//        0x1AA195509819DF535E832D7D8AF809B385EF96A85A5A2DCE0DB7F9D72954F829_cppui254};
+//    std::array<typename poseidon_policy::element_type, poseidon_policy::state_words> expected_state = {
+//        0x1A3FBD7D8C00BD0C3D4BC1DD41BF7FAA5903518DA636955D98712F9AC6D6DDFA_cppui254,
+//        0x1AA195509819DF535E832D7D8AF809B385EF96A85A5A2DCE0DB7F9D72954F829_cppui254,
+//        0
+//    };
+//    sponge_construction_type sponge;
+//    
+//    sponge.absorb(input);
+//
+//    BOOST_CHECK_EQUAL(sponge.state, expected_state);
+//}
+//
+//BOOST_AUTO_TEST_CASE(poseidon_kimchi_test_7) {
+//    using field_type = fields::pallas_base_field;
+//    using poseidon_policy = mina_poseidon_policy<field_type>;
+//    using sponge_construction_type = poseidon_sponge_construction<poseidon_policy>;
+//
+//    std::vector<field_type::value_type> input = {
+//        0x3CF70C3A89749A45DB5236B8DE167A37762526C45270138A9FCDF2352B1899DA_cppui254,
+//        0x1BDF55BC84C1A0E0F7F6834949FCF90279B9D21C17DBC9928202C49039570598_cppui254,
+//        0x09441E95A82199EFC390152C5039C0D0566A90B7F6D1AA5813B2DAB90110FF90_cppui254,
+//        0x375B4A9785503C24531723DB1F31B50B79C3D1EC9F95DB7645A3EDA03862B588_cppui254,
+//        0x12688FE351ED01F3BB2EB6B0FA2A70FB232654F32B08990DC3A411E527776A89_cppui254};
+//
+//    std::array<typename poseidon_policy::element_type, poseidon_policy::state_words>  expected_state_absorb = {
+//        0x2437F72484D8C5483D75F898376BC3EE29EDF2F7EF5305A3C61B937654954000_cppui254,
+//        0x16F954CD8F2B73D797170C5124F31A65160A3FCA92B77709E564075C2405BF80_cppui254,
+//        0x3696E4E8F08273FFEFDAD72C5002D103E9B8976F6579A010D6CC2A75B276851F_cppui254};
+//    sponge_construction_type sponge;
+//    
+//    sponge.absorb(input);
+//
+//    BOOST_CHECK(sponge.state == expected_state_absorb);
+//
+//    typename poseidon_policy::element_type expected_challenge = 
+//        0x0CA2C3342C2959D7CD94B5C9D4DC55900F5F60B345F714827C8B907752D5A209_cppui254;
+//    typename poseidon_policy::element_type challenge = sponge.squeeze();
+//
+//    BOOST_CHECK_EQUAL(challenge, expected_challenge);
+//}
 
 BOOST_AUTO_TEST_CASE(poseidon_original_test_254_2) {
     test_original_poseidon<fields::alt_bn128_scalar_field<254>, 2>(


### PR DESCRIPTION
Mina Poseidon uses the first element state[0] as the hash result, while we use the last one, state[2], so their test vectors do not apply any more.